### PR TITLE
Explicit close of all FileReader

### DIFF
--- a/src/main/java/sk/tomsik68/mclauncher/impl/login/yggdrasil/YDLoginService.java
+++ b/src/main/java/sk/tomsik68/mclauncher/impl/login/yggdrasil/YDLoginService.java
@@ -117,7 +117,9 @@ public final class YDLoginService implements ILoginService {
         JSONObject obj = new JSONObject();
         if (file.exists()) {
             MCLauncherAPI.log.fine("The file already exists. YDLoginService won't overwrite client token.");
-            obj = (JSONObject) JSONValue.parse(new FileReader(file));
+            FileReader fileReader = new FileReader(file);
+            obj = (JSONObject) JSONValue.parse(fileReader);
+            fileReader.close();
             if (obj.containsKey("clientToken"))
                 return;
             file.delete();
@@ -138,7 +140,9 @@ public final class YDLoginService implements ILoginService {
     }
 
     public void loadFrom(File file) throws Exception {
-        JSONObject obj = (JSONObject) JSONValue.parse(new FileReader(file));
+        FileReader fileReader = new FileReader(file);
+        JSONObject obj = (JSONObject) JSONValue.parse(fileReader);
+        fileReader.close();
         clientToken = UUID.fromString(obj.get("clientToken").toString());
         MCLauncherAPI.log.fine("Loaded client token: " + clientToken.toString());
     }

--- a/src/main/java/sk/tomsik68/mclauncher/impl/login/yggdrasil/YDProfileIO.java
+++ b/src/main/java/sk/tomsik68/mclauncher/impl/login/yggdrasil/YDProfileIO.java
@@ -24,7 +24,9 @@ public final class YDProfileIO implements IProfileIO {
 
     @Override
     public IProfile[] read() throws Exception {
+        FileReader fileReader = new FileReader(dest);
         JSONObject root = (JSONObject) JSONValue.parse(new FileReader(dest));
+        fileReader.close();
 
         JSONObject authDatabase = (JSONObject) root.get("authenticationDatabase");
         IProfile[] result = new IProfile[authDatabase.size()];

--- a/src/main/java/sk/tomsik68/mclauncher/impl/versions/mcdownload/MCDResourcesInstaller.java
+++ b/src/main/java/sk/tomsik68/mclauncher/impl/versions/mcdownload/MCDResourcesInstaller.java
@@ -39,7 +39,9 @@ final class MCDResourcesInstaller {
         if (!indexDest.exists() || indexDest.length() == 0)
             FileUtils.downloadFileWithProgress(indexDownloadURL, indexDest, progress);
         // parse it from JSON
-        JSONObject jsonAssets = (JSONObject) JSONValue.parse(new FileReader(indexDest));
+        FileReader fileReader = new FileReader(indexDest);
+        JSONObject jsonAssets = (JSONObject) JSONValue.parse(fileReader);
+        fileReader.close();
         AssetIndex assets = new AssetIndex(index, jsonAssets);
         // and download individual assets inside it
         downloadAssetList(assets, progress);

--- a/src/main/java/sk/tomsik68/mclauncher/impl/versions/mcdownload/MCDownloadLocalVersionList.java
+++ b/src/main/java/sk/tomsik68/mclauncher/impl/versions/mcdownload/MCDownloadLocalVersionList.java
@@ -54,7 +54,9 @@ final class MCDownloadLocalVersionList extends Observable<String> implements IVe
             return null;
         }
         File jsonFile = new File(versionFolder, versionFolder.getName().concat(".json"));
-        MCDownloadVersion result = new MCDownloadVersion((JSONObject) JSONValue.parse(new FileReader(jsonFile)));
+        FileReader fileReader = new FileReader(jsonFile);
+        MCDownloadVersion result = new MCDownloadVersion((JSONObject) JSONValue.parse(fileReader));
+        fileReader.close();
         return result;
     }
 


### PR DESCRIPTION
Hi,

I found a bug in the API, all FileReader need to be close. If not, it throw some exception when you try to delete file associated to the reader.

Exception throw in my launcher : 
```
java.io.IOException: Couldn't delete 'C:\Users\Safranil\AppData\Roaming\.miroa\versions\1.7.10\1.7.10.json'
	at sk.tomsik68.mclauncher.util.FileUtils.createFileSafely(FileUtils.java:22)
	at sk.tomsik68.mclauncher.util.FileUtils.writeFile(FileUtils.java:86)
	at sk.tomsik68.mclauncher.impl.versions.mcdownload.MCDownloadVersionInstaller.install(MCDownloadVersionInstaller.java:128)
	at sk.tomsik68.mclauncher.backend.MinecraftLauncherBackend.updateMinecraft(MinecraftLauncherBackend.java:62)
	at safranil.minecraft.miroa.MainController$1.call(MainController.java:140)
	at safranil.minecraft.miroa.MainController$1.call(MainController.java:76)
	at javafx.concurrent.Task$TaskCallable.call(Task.java:1423)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:745)
```