### PR TITLE
Corrected a weird bug when space are in the path causing Minecraft to not starting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   </build>
     <groupId>sk.tomsik68</groupId>
     <artifactId>mclauncher-api</artifactId>
-    <version>0.3.1</version>
+    <version>0.3.3</version>
     <dependencies>
         <dependency>
             <groupId>net.minidev</groupId>

--- a/src/main/java/sk/tomsik68/mclauncher/impl/versions/mcdownload/MCDownloadVersionLauncher.java
+++ b/src/main/java/sk/tomsik68/mclauncher/impl/versions/mcdownload/MCDownloadVersionLauncher.java
@@ -53,8 +53,14 @@ final class MCDownloadVersionLauncher implements IVersionLauncher {
         } else
             subst.setVariable("user_properties", "{}");
 
-        args = subst.substitute(args);
-        return args.split(" ");
+        String[] splitArgs = args.split(" ");
+
+        if (splitArgs.length > 0) {
+            for (int i = 0; i < splitArgs.length; ++i) {
+                splitArgs[i] = subst.substitute(splitArgs[i]);
+            }
+        }
+        return splitArgs;
     }
 
     @Override


### PR DESCRIPTION
As explained in the title, this part of (previous) code break Minecraft by splitting path in two or more arguments.

Now, the args are split before any replacement, this method permit space in path.