### PR TITLE
minimumLauncherVersion can be absent in JSON file

### DIFF
--- a/src/main/java/sk/tomsik68/mclauncher/impl/versions/mcdownload/MCDownloadVersion.java
+++ b/src/main/java/sk/tomsik68/mclauncher/impl/versions/mcdownload/MCDownloadVersion.java
@@ -40,7 +40,8 @@ final class MCDownloadVersion implements IVersion, IJSONSerializable {
         if (json.containsKey("processArguments"))
             processArgs = json.get("processArguments").toString();
         minecraftArgs = json.get("minecraftArguments").toString();
-        minimumLauncherVersion = Integer.parseInt(json.get("minimumLauncherVersion").toString());
+        if (json.containsKey("minimumLauncherVersion"))
+            minimumLauncherVersion = Integer.parseInt(json.get("minimumLauncherVersion").toString());
         mainClass = json.get("mainClass").toString();
         if (json.containsKey("assets"))
             assets = json.get("assets").toString();


### PR DESCRIPTION
minimumLauncherVersion is not provided by Forge for 1.12.2.