### PR TITLE
Add constructor for pass custom url for auth

### DIFF
--- a/src/main/java/sk/tomsik68/mclauncher/backend/GlobalAuthenticationSystem.java
+++ b/src/main/java/sk/tomsik68/mclauncher/backend/GlobalAuthenticationSystem.java
@@ -43,7 +43,7 @@ public final class GlobalAuthenticationSystem {
     public static ISession login(String profileName) throws Exception {
         // initialise login service in the working directory
         File workingDirectory = Platform.getCurrentPlatform().getWorkingDirectory();
-        YDLoginService loginService = new YDLoginService();
+        YDLoginService loginService = YDLoginService.mojang();
         loginService.load(workingDirectory);
 
         // read profiles
@@ -82,7 +82,7 @@ public final class GlobalAuthenticationSystem {
     public static ISession doPasswordLogin(String username, String password) throws Exception {
         // initialise login service in the working directory
         File workingDirectory = Platform.getCurrentPlatform().getWorkingDirectory();
-        YDLoginService loginService = new YDLoginService();
+        YDLoginService loginService = YDLoginService.mojang();
         try {
             loginService.load(workingDirectory);
         } catch (FileNotFoundException ex) {

--- a/src/main/java/sk/tomsik68/mclauncher/impl/login/yggdrasil/YDLoginService.java
+++ b/src/main/java/sk/tomsik68/mclauncher/impl/login/yggdrasil/YDLoginService.java
@@ -23,9 +23,9 @@ import sk.tomsik68.mclauncher.util.HttpUtils;
 
 public final class YDLoginService implements ILoginService {
     public static UUID clientToken = UUID.randomUUID();
-    private final String PASSWORD_LOGIN_URL;
-    private final String SESSION_LOGIN_URL;
-    private final String SESSION_LOGOUT_URL;
+    private final String passwordLoginUrl;
+    private final String sessionLoginUrl;
+    private final String sessionLogoutUrl;
 
     /**
      * Keep for back-capability
@@ -66,9 +66,9 @@ public final class YDLoginService implements ILoginService {
      * If argument is null, use default value
      */
     private YDLoginService(@NotNull String baseUrl) {
-        PASSWORD_LOGIN_URL = baseUrl + "authenticate";
-        SESSION_LOGIN_URL = baseUrl + "refresh";
-        SESSION_LOGOUT_URL = baseUrl + "invalidate";
+        passwordLoginUrl = baseUrl + "authenticate";
+        sessionLoginUrl = baseUrl + "refresh";
+        sessionLogoutUrl = baseUrl + "invalidate";
     }
 
     @Override
@@ -131,7 +131,7 @@ public final class YDLoginService implements ILoginService {
         MCLauncherAPI.log.fine("Using session ID login");
         YDSessionLoginRequest request = new YDSessionLoginRequest(profile.getPassword(), clientToken.toString());
 
-        YDLoginResponse response = doCheckedLoginPost(SESSION_LOGIN_URL, request);
+        YDLoginResponse response = doCheckedLoginPost(sessionLoginUrl, request);
 
         return response;
     }
@@ -140,7 +140,7 @@ public final class YDLoginService implements ILoginService {
         MCLauncherAPI.log.fine("Using password-based login");
         YDPasswordLoginRequest request = new YDPasswordLoginRequest(profile.getName(), profile.getPassword(), clientToken.toString());
 
-        YDLoginResponse response = doCheckedLoginPost(PASSWORD_LOGIN_URL, request);
+        YDLoginResponse response = doCheckedLoginPost(passwordLoginUrl, request);
 
         return response;
     }
@@ -192,7 +192,7 @@ public final class YDLoginService implements ILoginService {
     @Override
     public void logout(ISession session) throws Exception {
         YDLogoutRequest request = new YDLogoutRequest(session, clientToken);
-        String response = doLoginPost(SESSION_LOGOUT_URL, request);
+        String response = doLoginPost(sessionLogoutUrl, request);
         if("".equals(response)) {
             MCLauncherAPI.log.fine("Logout successful.");
         } else {

--- a/src/main/java/sk/tomsik68/mclauncher/impl/login/yggdrasil/YDLoginService.java
+++ b/src/main/java/sk/tomsik68/mclauncher/impl/login/yggdrasil/YDLoginService.java
@@ -22,11 +22,33 @@ import sk.tomsik68.mclauncher.util.HttpUtils;
 
 public final class YDLoginService implements ILoginService {
     public static UUID clientToken = UUID.randomUUID();
-    private static final String PASSWORD_LOGIN_URL = "https://authserver.mojang.com/authenticate";
-    private static final String SESSION_LOGIN_URL = "https://authserver.mojang.com/refresh";
-    private static final String SESSION_LOGOUT_URL = "https://authserver.mojang.com/invalidate";
+    private static String PASSWORD_LOGIN_URL = "https://authserver.mojang.com/authenticate";
+    private static String SESSION_LOGIN_URL = "https://authserver.mojang.com/refresh";
+    private static String SESSION_LOGOUT_URL = "https://authserver.mojang.com/invalidate";
 
     public YDLoginService() {
+    }
+    
+    /**
+     * Constructor for debug/custom auth url.
+     * If argument is null, use default value
+     *
+     * @param passwordLoginUrl url for pass login and password
+     * @param sessionLoginUrl url for login by session (or refresh)
+     * @param sessionLogoutUrl url for logout by session
+     */
+    public YDLoginService(@Nullable String passwordLoginUrl,
+                          @Nullable String sessionLoginUrl,
+                          @Nullable String sessionLogoutUrl) {
+        if (passwordLoginUrl != null) {
+            PASSWORD_LOGIN_URL = passwordLoginUrl;
+        }
+        if (sessionLoginUrl != null) {
+            SESSION_LOGIN_URL = sessionLoginUrl;
+        }
+        if (sessionLogoutUrl != null) {
+            SESSION_LOGOUT_URL = sessionLogoutUrl;
+        }
     }
 
     @Override
@@ -38,12 +60,12 @@ public final class YDLoginService implements ILoginService {
         }
         else if(profile instanceof YDAuthProfile) {
             response = doSessionLogin(profile);
-        
+
         } else {
             throw new IllegalArgumentException("YDLoginService can't deal with custom profile class: " + profile.getClass().getName());
-        
+
         }
-        
+
         MCLauncherAPI.log.fine("Login successful. Updating profile...");
         YDSession result = new YDSession(response);
         if(profile instanceof YDAuthProfile)
@@ -75,12 +97,12 @@ public final class YDLoginService implements ILoginService {
 
 		JSONObject jsonObject = (JSONObject)JSONValue.parse(jsonString);
         YDLoginResponse response = new YDLoginResponse(jsonObject);
-        
+
         if(response.getError() != null) {
             MCLauncherAPI.log.fine("Login response error. JSON STRING: '".concat(jsonString).concat("'"));
 			throw new YDServiceAuthenticationException("Authentication Failed: " + response.getMessage(),
 					new LoginException("Error ".concat(response.getError()).concat(" : ").concat(response.getMessage())));
-		
+
         }
         return response;
     }

--- a/src/main/java/sk/tomsik68/mclauncher/impl/login/yggdrasil/YDLoginService.java
+++ b/src/main/java/sk/tomsik68/mclauncher/impl/login/yggdrasil/YDLoginService.java
@@ -6,6 +6,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.UUID;
 
+import com.sun.istack.internal.NotNull;
 import net.minidev.json.JSONObject;
 import net.minidev.json.JSONStyle;
 import net.minidev.json.JSONValue;
@@ -22,33 +23,52 @@ import sk.tomsik68.mclauncher.util.HttpUtils;
 
 public final class YDLoginService implements ILoginService {
     public static UUID clientToken = UUID.randomUUID();
-    private static String PASSWORD_LOGIN_URL = "https://authserver.mojang.com/authenticate";
-    private static String SESSION_LOGIN_URL = "https://authserver.mojang.com/refresh";
-    private static String SESSION_LOGOUT_URL = "https://authserver.mojang.com/invalidate";
+    private final String PASSWORD_LOGIN_URL;
+    private final String SESSION_LOGIN_URL;
+    private final String SESSION_LOGOUT_URL;
 
+    /**
+     * Keep for back-capability
+     * Will be removed in the future!
+     *
+     * @deprecated use #mojang() static method please
+     */
+    @Deprecated
     public YDLoginService() {
+        this("https://authserver.mojang.com/");
     }
-    
+
+    /**
+     * Create instance YDLoginService with default Mojang auth server
+     *
+     * @return YDLoginService new instance
+     */
+    public static YDLoginService mojang() {
+        return new YDLoginService("https://authserver.mojang.com/");
+    }
+
+    /**
+     * Create instance YDLoginService with default Mojang auth server
+     * baseUrl + authenticate
+     * baseUrl + refresh
+     * baseUrl + invalidate
+     *
+     * @see YDLoginService#mojang() also
+     * @param baseUrl start url for auth path
+     * @return YDLoginService new instance
+     */
+    public static YDLoginService custom(@NotNull String baseUrl) {
+        return new YDLoginService(baseUrl);
+    }
+
     /**
      * Constructor for debug/custom auth url.
      * If argument is null, use default value
-     *
-     * @param passwordLoginUrl url for pass login and password
-     * @param sessionLoginUrl url for login by session (or refresh)
-     * @param sessionLogoutUrl url for logout by session
      */
-    public YDLoginService(@Nullable String passwordLoginUrl,
-                          @Nullable String sessionLoginUrl,
-                          @Nullable String sessionLogoutUrl) {
-        if (passwordLoginUrl != null) {
-            PASSWORD_LOGIN_URL = passwordLoginUrl;
-        }
-        if (sessionLoginUrl != null) {
-            SESSION_LOGIN_URL = sessionLoginUrl;
-        }
-        if (sessionLogoutUrl != null) {
-            SESSION_LOGOUT_URL = sessionLogoutUrl;
-        }
+    private YDLoginService(@NotNull String baseUrl) {
+        PASSWORD_LOGIN_URL = baseUrl + "authenticate";
+        SESSION_LOGIN_URL = baseUrl + "refresh";
+        SESSION_LOGOUT_URL = baseUrl + "invalidate";
     }
 
     @Override

--- a/src/main/java/sk/tomsik68/mclauncher/impl/login/yggdrasil/YDLoginService.java
+++ b/src/main/java/sk/tomsik68/mclauncher/impl/login/yggdrasil/YDLoginService.java
@@ -91,7 +91,6 @@ public final class YDLoginService implements ILoginService {
         if(profile instanceof YDAuthProfile)
             ((YDAuthProfile)profile).update(result);
         return result;
-      
     }
 
     public IProfile createProfile(ISession session){


### PR DESCRIPTION
# Background

Now if we want to use a custom auth server (for debugging or testing) we need a fork repo

# Changed
- Now we can pass URL for login in YDLoginService constructor 

# Test plan
- Use the new constructor and pass URL for mocking
- Check that library use this urls