### PR TITLE
Cleanup gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,9 @@
 /META-INF
 /minecraft.src
-/toms-mclauncher.log
-/toms-mclauncher.log.1
-/toms-mclauncher.log.2
+*.txt
 /savetest
 /savetest-json
-/README.md
 /testmc/*
-/testmc
 /dest
 /dist
 /lib
@@ -17,15 +13,9 @@
 /testlaunch.sh
 /tools/servicefinder/*_src
 /tools/servicefinder/*_disasm
-/tools/servicefinder/*.jar
 /tools/servicefinder/versions.json
 /Official-MCLauncher
-/target/
-/mcCommand.txt
-/mcerr.log
-/mclauncher-api.iml
-/mcout.log
-/servers_savetest.dat
+*.dat
 /build/
 /.gradle/
 /build.gradle.idea/
@@ -36,6 +26,7 @@
 
 # Log file
 *.log
+*.log.*
 
 # BlueJ files
 *.ctxt
@@ -65,14 +56,13 @@ release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
-# https://github.com/takari/maven-wrapper#usage-without-binary-jar
-.mvn/wrapper/maven-wrapper.jar
 
 # Jetbrains section https://github.com/github/gitignore/blob/master/Global/JetBrains.gitignore
 .idea
 
 # File-based project format
 *.iws
+*.iml
 
 # IntelliJ
 out/
@@ -82,6 +72,3 @@ out/
 
 # JIRA plugin
 atlassian-ide-plugin.xml
-
-# Cursive Clojure plugin
-.idea/replstate.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /META-INF
 /minecraft.src
 *.txt
+*.zip
 /savetest
 /savetest-json
 /testmc/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,3 @@
-/forms-1.3.0.jar
-/forms-1.3.0-src.zip
-/miglayout15-swing.jar
-/miglayout-src.zip
-/minecraft.src.zip
 /META-INF
 /minecraft.src
 /toms-mclauncher.log
@@ -34,3 +29,59 @@
 /build/
 /.gradle/
 /build.gradle.idea/
+
+# Java section https://github.com/github/gitignore/blob/master/Java.gitignore
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+# Maven section https://github.com/github/gitignore/blob/master/Maven.gitignore
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+# https://github.com/takari/maven-wrapper#usage-without-binary-jar
+.mvn/wrapper/maven-wrapper.jar
+
+# Jetbrains section https://github.com/github/gitignore/blob/master/Global/JetBrains.gitignore
+.idea
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml


### PR DESCRIPTION
# Background

Right now I'm having a lot of trouble using the repository because of the redundant and incorrect gitignore file

# Changes
- Use ignore list from https://github.com/github/gitignore/blob/master/Java.gitignore
- Use ignore list form https://github.com/github/gitignore/blob/master/Global/JetBrains.gitignore
- Use ignore list from https://github.com/github/gitignore/blob/master/Maven.gitignore
- Ignore all file with `txt`,`jar`, `log`, `dat` extensions by default. If we want add file with this extension, use `!path/to/file.jar`
- Remove `README.md` from ignore (Why? O_o)