### PR TITLE
Create buffer once on copy/download

### DIFF
--- a/src/main/java/sk/tomsik68/mclauncher/util/FileUtils.java
+++ b/src/main/java/sk/tomsik68/mclauncher/util/FileUtils.java
@@ -53,10 +53,9 @@ public final class FileUtils {
         progress.setMax(len);
 
         int readBytes = 0;
-        byte[] block;
+        byte[] block = new byte[524_288]; // 524 KB
 
         while (readBytes < len) {
-            block = new byte[8192];
             int readNow = in.read(block);
             if (readNow > 0)
                 out.write(block, 0, readNow);

--- a/src/main/java/sk/tomsik68/mclauncher/util/FileUtils.java
+++ b/src/main/java/sk/tomsik68/mclauncher/util/FileUtils.java
@@ -61,6 +61,9 @@ public final class FileUtils {
                 out.write(block, 0, readNow);
             progress.setProgress(readBytes);
             readBytes += readNow;
+            if (Thread.interrupted()) {
+                throw new InterruptedException();
+            }
         }
         out.flush();
         out.close();

--- a/src/main/java/sk/tomsik68/mclauncher/util/FileUtils.java
+++ b/src/main/java/sk/tomsik68/mclauncher/util/FileUtils.java
@@ -71,9 +71,8 @@ public final class FileUtils {
         createFileSafely(to);
         BufferedInputStream bis = new BufferedInputStream(new FileInputStream(from));
         BufferedOutputStream bos = new BufferedOutputStream(new FileOutputStream(to));
-        byte[] block;
+        byte[] block = new byte[8192];
         while (bis.available() > 0) {
-            block = new byte[8192];
             final int readNow = bis.read(block);
             bos.write(block, 0, readNow);
         }

--- a/src/main/java/sk/tomsik68/mclauncher/util/FileUtils.java
+++ b/src/main/java/sk/tomsik68/mclauncher/util/FileUtils.java
@@ -53,7 +53,7 @@ public final class FileUtils {
         progress.setMax(len);
 
         int readBytes = 0;
-        byte[] block = new byte[524_288]; // 524 KB
+        byte[] block = new byte[8192];
 
         while (readBytes < len) {
             int readNow = in.read(block);


### PR DESCRIPTION
# Background

Now we create buffer array each time when download or copy file. This is increase CPU load for Garbage Collector and decrease download speed on high-speed connection (1Gbit/s, for example)

# Changes
- Move create byte array from cycle body when download file
- Move create byte array from cycle body when copy file
- Throw interrupt exception if thread interrupted