### PR TITLE
Add response from server in exception

### DIFF
--- a/src/main/java/sk/tomsik68/mclauncher/impl/login/yggdrasil/YDLoginResponse.java
+++ b/src/main/java/sk/tomsik68/mclauncher/impl/login/yggdrasil/YDLoginResponse.java
@@ -1,18 +1,27 @@
 package sk.tomsik68.mclauncher.impl.login.yggdrasil;
 
+import com.sun.istack.internal.Nullable;
 import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
 
 import java.util.HashMap;
 
 final class YDLoginResponse extends YDResponse {
+    @Nullable
     private final String sessionID, clientToken;
+    @Nullable
     private final YDPartialGameProfile selectedProfile;
     private HashMap<String, YDPartialGameProfile> profiles = new HashMap<String, YDPartialGameProfile>();
     private YDUserObject user;
 
     public YDLoginResponse(JSONObject json) {
         super(json);
+        if (getError() != null) {
+            sessionID = null;
+            clientToken = null;
+            selectedProfile = null;
+            return;
+        }
         sessionID = json.get("accessToken").toString();
         clientToken = json.get("clientToken").toString();
         selectedProfile = new YDPartialGameProfile((JSONObject) json.get("selectedProfile"));

--- a/src/main/java/sk/tomsik68/mclauncher/impl/login/yggdrasil/YDLoginService.java
+++ b/src/main/java/sk/tomsik68/mclauncher/impl/login/yggdrasil/YDLoginService.java
@@ -38,12 +38,12 @@ public final class YDLoginService implements ILoginService {
         }
         else if(profile instanceof YDAuthProfile) {
             response = doSessionLogin(profile);
-        
+
         } else {
             throw new IllegalArgumentException("YDLoginService can't deal with custom profile class: " + profile.getClass().getName());
-        
+
         }
-        
+
         MCLauncherAPI.log.fine("Login successful. Updating profile...");
         YDSession result = new YDSession(response);
         if(profile instanceof YDAuthProfile)
@@ -75,12 +75,13 @@ public final class YDLoginService implements ILoginService {
 
 		JSONObject jsonObject = (JSONObject)JSONValue.parse(jsonString);
         YDLoginResponse response = new YDLoginResponse(jsonObject);
-        
+
         if(response.getError() != null) {
             MCLauncherAPI.log.fine("Login response error. JSON STRING: '".concat(jsonString).concat("'"));
 			throw new YDServiceAuthenticationException("Authentication Failed: " + response.getMessage(),
-					new LoginException("Error ".concat(response.getError()).concat(" : ").concat(response.getMessage())));
-		
+					new LoginException("Error ".concat(response.getError()).concat(" : ").concat(response.getMessage())),
+                    response);
+
         }
         return response;
     }

--- a/src/main/java/sk/tomsik68/mclauncher/impl/login/yggdrasil/YDServiceAuthenticationException.java
+++ b/src/main/java/sk/tomsik68/mclauncher/impl/login/yggdrasil/YDServiceAuthenticationException.java
@@ -1,25 +1,32 @@
 package sk.tomsik68.mclauncher.impl.login.yggdrasil;
 
+import com.sun.istack.internal.Nullable;
+
 public class YDServiceAuthenticationException extends Exception {
-	
-	/**
-	 * 
-	 */
-	private static final long serialVersionUID = -7648783527451750219L;
-	
 	private Exception thrown;
-	
+	@Nullable
+	private YDResponse reason;
+
 	public YDServiceAuthenticationException(String msg) {
 		super(msg);
 	}
-	
+
 	public YDServiceAuthenticationException(String msg, Exception e) {
 		super(msg);
 		this.thrown = e;
 	}
-	
+
+	public YDServiceAuthenticationException(String msg, Exception e, YDResponse reason) {
+		this(msg, e);
+		this.reason = reason;
+	}
+
 	public Exception getThrown() {
 		return thrown;
 	}
 
+	@Nullable
+	public YDResponse getReason() {
+		return reason;
+	}
 }


### PR DESCRIPTION
# Background

Now we put reason of exception only in exception message. But sometimes clients need raw answer from server for display message for user.

# Changes

- Add optional argument `YDResponse reason`
- Remove `serialVersionUID` field. For what? 