### PR TITLE
Use arguments from parent version

### DIFF
--- a/src/main/java/sk/tomsik68/mclauncher/impl/versions/mcdownload/ArgumentList.java
+++ b/src/main/java/sk/tomsik68/mclauncher/impl/versions/mcdownload/ArgumentList.java
@@ -45,4 +45,10 @@ final class ArgumentList implements Iterable<Argument> {
     public Iterator<Argument> iterator() {
         return args.iterator();
     }
+
+    public ArgumentList plus(ArgumentList source) {
+        final List<Argument> newList = new ArrayList<>(this.args);
+        newList.addAll(source.args);
+        return new ArgumentList(newList);
+    }
 }

--- a/src/main/java/sk/tomsik68/mclauncher/impl/versions/mcdownload/MCDownloadVersion.java
+++ b/src/main/java/sk/tomsik68/mclauncher/impl/versions/mcdownload/MCDownloadVersion.java
@@ -221,11 +221,17 @@ final class MCDownloadVersion implements IVersion, IJSONSerializable {
             throw new IllegalArgumentException("Wrong inheritance version passed!");
         }
 
-        if(gameArgs.isEmpty())
+        if(gameArgs.isEmpty()) {
             gameArgs = parent.gameArgs;
+        } else {
+            gameArgs = gameArgs.plus(parent.gameArgs);
+        }
 
-        if (jvmArgs.isEmpty())
+        if (jvmArgs.isEmpty()) {
             jvmArgs = parent.jvmArgs;
+        } else {
+            jvmArgs = jvmArgs.plus(parent.jvmArgs);
+        }
 
         if(minimumLauncherVersion == null)
             minimumLauncherVersion = parent.getMinimumLauncherVersion();


### PR DESCRIPTION
# Background

Now we apply argument only from current version. But original launcher merge original and parent versions. For example, forge argument version for 1.16.5:
```
  "arguments": {
        "game": [
            "--launchTarget",
            "fmlclient",
            "--fml.forgeVersion",
            "36.0.1",
            "--fml.mcVersion",
            "1.16.5",
            "--fml.forgeGroup",
            "net.minecraftforge",
            "--fml.mcpVersion",
            "20210115.111550"
        ]
    }
```

Current behaviour is incorrect and some version just not launch.

# Changes
- Add gameArgs in current version from parent version
- Add jvmArgs from parent version